### PR TITLE
Easy for admins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .idea
-data/
-cgi-bin/
+bin/
+webroot/

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,13 @@ endif
 
 DB_FILENAME=$(TEMP_DIR)/bhproxy.sqlite
 IMAGE_DIRECTORY=$(TEMP_DIR)/bhproxy-images
+IMAGE_URL=http://localhost:8080/images
 
 start:
 	if [ ! -f $(DB_FILENAME) ]; then touch $(DB_FILENAME); fi
 	if [ ! -d $(IMAGE_DIRECTORY) ]; then mkdir $(IMAGE_DIRECTORY); fi
-	DB_FILENAME=$(DB_FILENAME) IMAGE_DIRECTORY=$(IMAGE_DIRECTORY) python3 -m http.server --bind localhost --cgi 8080
+	if [ ! -L ./images ]; then ln -s $(IMAGE_DIRECTORY) images; fi
+	DB_FILENAME=$(DB_FILENAME) IMAGE_DIRECTORY=$(IMAGE_DIRECTORY) IMAGE_URL=$(IMAGE_URL) python3 -m http.server --bind localhost --cgi 8080
 
 start-minihttpd:
 	if [ -f /tmp/mini_httpd.log ]; then rm /tmp/mini_httpd.log; fi

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 PWD=$(shell pwd)
 WEBROOT=$(PWD)/webroot
-DB_FILENAME=$(WEBROOT)/data/bhproxy.sqlite
-IMAGE_DIRECTORY=$(WEBROOT)/docs/images
-IMAGE_URL=http://localhost:8080/images
+BHP_DB_FILENAME=$(WEBROOT)/data/bhproxy.sqlite
+BHP_IMAGE_DIRECTORY=$(WEBROOT)/docs/images
+BHP_IMAGE_URL=http://localhost:8080/images
 
 .PHONY:ensure-webroot
 ensure-webroot:
@@ -39,7 +39,7 @@ start: ensure-webroot build-dev
 	if [ ! -f $(DB_FILENAME) ]; then touch $(DB_FILENAME); fi
 	if [ ! -f $(WEBROOT)/docs/favicon.ico ]; then touch $(WEBROOT)/docs/favicon.ico; fi
 	cp index.html $(WEBROOT)/docs/
-	DB_FILENAME=$(DB_FILENAME) IMAGE_DIRECTORY=$(IMAGE_DIRECTORY) IMAGE_URL=$(IMAGE_URL) \
+	BHP_DB_FILENAME=$(BHP_DB_FILENAME) BHP_IMAGE_DIRECTORY=$(BHP_IMAGE_DIRECTORY) BHP_IMAGE_URL=$(BHP_IMAGE_URL) \
 		python3 -m http.server --bind localhost --cgi 8080 -d $(WEBROOT)/docs
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,16 @@
+TEMP_DIR := $(TMPDIR)
+ifeq ($(TEMP_DIR),)
+    TEMP_DIR := $(TEMP)
+endif
+ifeq ($(TEMP_DIR),)
+    TEMP_DIR := /tmp
+endif
+
+DB_FILENAME=$(TEMP_DIR)/bhproxy.sqlite
+
 start:
-	python3 -m http.server --bind localhost --cgi 8080
+	if [ ! -f $(DB_FILENAME) ]; then touch $(DB_FILENAME); fi
+	DB_FILENAME=$(DB_FILENAME) python3 -m http.server --bind localhost --cgi 8080
 
 start-minihttpd:
 	if [ -f /tmp/mini_httpd.log ]; then rm /tmp/mini_httpd.log; fi
@@ -17,10 +28,12 @@ build-dev:
 
 test:
 	@go test ./pkg/feed
+	@go test ./pkg/utility
 	@go test ./pkg/db
 	@go test ./pkg/handler
 
 test-v:
 	@go test -v ./pkg/feed
+	@go test -v ./pkg/utility
 	@go test -v ./pkg/db
 	@go test -v ./pkg/handler

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,12 @@ ifeq ($(TEMP_DIR),)
 endif
 
 DB_FILENAME=$(TEMP_DIR)/bhproxy.sqlite
+IMAGE_DIRECTORY=$(TEMP_DIR)/bhproxy-images
 
 start:
 	if [ ! -f $(DB_FILENAME) ]; then touch $(DB_FILENAME); fi
-	DB_FILENAME=$(DB_FILENAME) python3 -m http.server --bind localhost --cgi 8080
+	if [ ! -d $(IMAGE_DIRECTORY) ]; then mkdir $(IMAGE_DIRECTORY); fi
+	DB_FILENAME=$(DB_FILENAME) IMAGE_DIRECTORY=$(IMAGE_DIRECTORY) python3 -m http.server --bind localhost --cgi 8080
 
 start-minihttpd:
 	if [ -f /tmp/mini_httpd.log ]; then rm /tmp/mini_httpd.log; fi

--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,48 @@
-TEMP_DIR := $(TMPDIR)
-ifeq ($(TEMP_DIR),)
-    TEMP_DIR := $(TEMP)
-endif
-ifeq ($(TEMP_DIR),)
-    TEMP_DIR := /tmp
-endif
-
-DB_FILENAME=$(TEMP_DIR)/bhproxy.sqlite
-IMAGE_DIRECTORY=$(TEMP_DIR)/bhproxy-images
+PWD=$(shell pwd)
+WEBROOT=$(PWD)/webroot
+DB_FILENAME=$(WEBROOT)/data/bhproxy.sqlite
+IMAGE_DIRECTORY=$(WEBROOT)/docs/images
 IMAGE_URL=http://localhost:8080/images
 
-start:
-	if [ ! -f $(DB_FILENAME) ]; then touch $(DB_FILENAME); fi
-	if [ ! -d $(IMAGE_DIRECTORY) ]; then mkdir $(IMAGE_DIRECTORY); fi
-	if [ ! -L ./images ]; then ln -s $(IMAGE_DIRECTORY) images; fi
-	DB_FILENAME=$(DB_FILENAME) IMAGE_DIRECTORY=$(IMAGE_DIRECTORY) IMAGE_URL=$(IMAGE_URL) python3 -m http.server --bind localhost --cgi 8080
+.PHONY:ensure-webroot
+ensure-webroot:
+	if [ ! -d $(WEBROOT)/docs/images ]; then mkdir -p $(WEBROOT)/docs/images; fi
+	if [ ! -d $(WEBROOT)/docs/cgi-bin ]; then mkdir -p $(WEBROOT)/docs/cgi-bin; fi
+	if [ ! -d $(WEBROOT)/data ]; then mkdir -p $(WEBROOT)/data; fi
 
-start-minihttpd:
-	if [ -f /tmp/mini_httpd.log ]; then rm /tmp/mini_httpd.log; fi
-	if [ -f /tmp/mini_httpd.pid ]; then rm /tmp/mini_httpd.pid; fi
-	mini_httpd -p 8080 -c "cgi-bin/**"  -l /tmp/mini_httpd.log -i /tmp/mini_httpd.pid
-
-stop-minihttpd:
-	kill -TERM `cat /tmp/mini_httpd.pid`
-
+.PHONY: build
 build:
-	@CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o cgi-bin/bhproxy cmd/main.go
+	if [ ! -d bin]; then mkdir bin
+	@CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o bin/bhproxy cmd/main.go
 
+.PHONY: build-dev
 build-dev:
-	@go build -o cgi-bin/bhproxy cmd/main.go
+	@go build -o bin/bhproxy cmd/main.go
 
+.PHONY: test
 test:
 	@go test ./pkg/feed
 	@go test ./pkg/utility
 	@go test ./pkg/db
 	@go test ./pkg/handler
 
+.PHONY: test-v
 test-v:
 	@go test -v ./pkg/feed
 	@go test -v ./pkg/utility
 	@go test -v ./pkg/db
 	@go test -v ./pkg/handler
+
+.PHONY: start
+start: ensure-webroot build-dev
+	if [ ! -L $(WEBROOT)/docs/cgi-bin/bhproxy ]; then ln -s $(PWD)/bin/bhproxy $(WEBROOT)/docs/cgi-bin/bhproxy; fi
+	if [ ! -f $(DB_FILENAME) ]; then touch $(DB_FILENAME); fi
+	if [ ! -f $(WEBROOT)/docs/favicon.ico ]; then touch $(WEBROOT)/docs/favicon.ico; fi
+	cp index.html $(WEBROOT)/docs/
+	DB_FILENAME=$(DB_FILENAME) IMAGE_DIRECTORY=$(IMAGE_DIRECTORY) IMAGE_URL=$(IMAGE_URL) \
+		python3 -m http.server --bind localhost --cgi 8080 -d $(WEBROOT)/docs
+
+.PHONY: clean
+clean:
+	rm -fR bin/
+	rm -fR $(WEBROOT)/

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ensure-webroot:
 
 .PHONY: build
 build:
-	if [ ! -d bin]; then mkdir bin
+	if [ ! -d bin ]; then mkdir bin; fi
 	@CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o bin/bhproxy cmd/main.go
 
 .PHONY: build-dev
@@ -33,14 +33,18 @@ test-v:
 	@go test -v ./pkg/db
 	@go test -v ./pkg/handler
 
+bin/.env:
+	echo BHP_DB_FILENAME=$(BHP_DB_FILENAME) >bin/.env
+	echo BHP_IMAGE_DIRECTORY=$(BHP_IMAGE_DIRECTORY) >>bin/.env
+	echo BHP_IMAGE_URL=$(BHP_IMAGE_URL) >>bin/.env
+
 .PHONY: start
-start: ensure-webroot build-dev
+start: ensure-webroot build-dev bin/.env
 	if [ ! -L $(WEBROOT)/docs/cgi-bin/bhproxy ]; then ln -s $(PWD)/bin/bhproxy $(WEBROOT)/docs/cgi-bin/bhproxy; fi
 	if [ ! -f $(DB_FILENAME) ]; then touch $(DB_FILENAME); fi
 	if [ ! -f $(WEBROOT)/docs/favicon.ico ]; then touch $(WEBROOT)/docs/favicon.ico; fi
 	cp index.html $(WEBROOT)/docs/
-	BHP_DB_FILENAME=$(BHP_DB_FILENAME) BHP_IMAGE_DIRECTORY=$(BHP_IMAGE_DIRECTORY) BHP_IMAGE_URL=$(BHP_IMAGE_URL) \
-		python3 -m http.server --bind localhost --cgi 8080 -d $(WEBROOT)/docs
+	python3 -m http.server --bind localhost --cgi 8080 -d $(WEBROOT)/docs
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ bhproxy reads following environment variables:
 * `BHP_IMAGE_DIRECTORY` - a rw path to store all images a without trailing slash. Required.
 * `BHP_IMAGE_URL` - prefix for image files located in `IMAGE_DIRECTORY` without a trailing slash. Optional, defaults to root (`/`).
 * `BHP_ALLOWED_FEED_IDS` - comma-separated list of Behold feed IDs which this proxy serves. Optional, defaults to all IDs are allowed.
+* `BHP_LOGFILE` - path to log file. Optional, defaults to STDERR.
 
 The environment variables can be set using a standard `.env` file which should be in the same directory with the executable.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ bhproxy reads following environment variables:
 * `BHP_IMAGE_URL` - prefix for image files located in `IMAGE_DIRECTORY` without a trailing slash. Optional, defaults to root (`/`).
 * `BHP_ALLOWED_FEED_IDS` - comma-separated list of Behold feed IDs which this proxy serves. Optional, defaults to all IDs are allowed.
 
+The environment variables can be set using a standard `.env` file which should be in the same directory with the executable.
+
 ## Developing
 
 * Build: `make build` or `make build-dev` creates a binary `bin/bhproxy`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# bhproxy - Behold.so proxy
+
+This is a proxy between HTML5 application and Behold.so web service.
+
+It simplifies JSON object served by Behold and takes load from the service.
+
+The bhproxy lives behind a web service via CGI which makes possible to run it in a regular LAMP web server.
+
+## Configuration
+
+bhproxy reads following environment variables:
+
+* `DB_FILENAME` - a path to rw file used to store SQLite database.
+
+## Developing
+
+* Build: `make build` or `make build-dev` creates a binary `cgi-bin/bhproxy`
+* Try: `make start` creates a Python3 web server. The binary answers at http://localhost:8080/cgi-bin/bhproxy?id=BEHOLD_FEED_ID
+* To run tests: `make test` or `make test-v`

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ The bhproxy lives behind a web service via CGI which makes possible to run it in
 
 bhproxy reads following environment variables:
 
-* `DB_FILENAME` - a path to rw file used to store SQLite database. Required.
-* `IMAGE_DIRECTORY` - a rw path to store all images a without trailing slash. Required.
-* `IMAGE_URL` - prefix for image files located in `IMAGE_DIRECTORY` without a trailing slash. Optional, defaults to root (`/`).
+* `BHP_DB_FILENAME` - a path to rw file used to store SQLite database. Required.
+* `BHP_IMAGE_DIRECTORY` - a rw path to store all images a without trailing slash. Required.
+* `BHP_IMAGE_URL` - prefix for image files located in `IMAGE_DIRECTORY` without a trailing slash. Optional, defaults to root (`/`).
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ The bhproxy lives behind a web service via CGI which makes possible to run it in
 
 bhproxy reads following environment variables:
 
-* `DB_FILENAME` - a path to rw file used to store SQLite database.
-* `IMAGE_DIRECTORY` - a rw path to store all images
+* `DB_FILENAME` - a path to rw file used to store SQLite database. Required.
+* `IMAGE_DIRECTORY` - a rw path to store all images a without trailing slash. Required.
+* `IMAGE_URL` - prefix for image files located in `IMAGE_DIRECTORY` without a trailing slash. Optional, defaults to root (`/`).
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ bhproxy reads following environment variables:
 * `BHP_DB_FILENAME` - a path to rw file used to store SQLite database. Required.
 * `BHP_IMAGE_DIRECTORY` - a rw path to store all images a without trailing slash. Required.
 * `BHP_IMAGE_URL` - prefix for image files located in `IMAGE_DIRECTORY` without a trailing slash. Optional, defaults to root (`/`).
+* `BHP_ALLOWED_FEED_IDS` - comma-separated list of Behold feed IDs which this proxy serves. Optional, defaults to all IDs are allowed.
 
 ## Developing
 
-* Build: `make build` or `make build-dev` creates a binary `cgi-bin/bhproxy`
+* Build: `make build` or `make build-dev` creates a binary `bin/bhproxy`
 * Try: `make start` creates a Python3 web server. The binary answers at http://localhost:8080/cgi-bin/bhproxy?id=BEHOLD_FEED_ID
+* To pass `BHP_ALLOWED_FEED_IDS` whitelist: `BHP_ALLOWED_FEED_IDS=JYK0zcST7PconDbzq1GL,JYK0bzSTZPConDbzq1XP make start`
 * To run tests: `make test` or `make test-v`

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The bhproxy lives behind a web service via CGI which makes possible to run it in
 bhproxy reads following environment variables:
 
 * `DB_FILENAME` - a path to rw file used to store SQLite database.
+* `IMAGE_DIRECTORY` - a rw path to store all images
 
 ## Developing
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,13 +4,25 @@ import (
 	"log"
 	"net/http"
 	"net/http/cgi"
+	"os"
 
 	"github.com/lattots/bhproxy/pkg/handler"
+	"github.com/lattots/bhproxy/pkg/utility"
 )
 
-const databaseFilename = "data/db.sqlite"
-
 func main() {
+	databaseFilename := os.Getenv("DB_FILENAME")
+	if databaseFilename == "" {
+		log.Fatal("required environment variable db_filename is not set or is empty")
+	}
+
+	if !utility.FileExists(databaseFilename) {
+		log.Fatalf("database file %s does not exist", databaseFilename)
+	}
+	if !utility.FileIsWriteable(databaseFilename) {
+		log.Fatalf("database file %s is not writeable", databaseFilename)
+	}
+
 	h, err := handler.NewSqliteHandler(databaseFilename)
 	if err != nil {
 		log.Fatalf("failed to create sqlite handler: %s", err)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	databaseFilename := os.Getenv("DB_FILENAME")
+	databaseFilename := os.Getenv("BHP_DB_FILENAME")
 	if databaseFilename == "" {
 		log.Fatal("required environment variable db_filename is not set or is empty")
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,11 +6,21 @@ import (
 	"net/http/cgi"
 	"os"
 
+	"github.com/joho/godotenv"
+
 	"github.com/lattots/bhproxy/pkg/handler"
 	"github.com/lattots/bhproxy/pkg/utility"
 )
 
 func main() {
+	dotEnvPath := utility.GetDotEnvPath()
+	if utility.FileExists(dotEnvPath) {
+		err := godotenv.Load(utility.GetDotEnvPath())
+		if err != nil {
+			log.Fatalf("could not read .env file at %s: %s", dotEnvPath, err)
+		}
+	}
+
 	databaseFilename := os.Getenv("BHP_DB_FILENAME")
 	if databaseFilename == "" {
 		log.Fatal("required environment variable db_filename is not set or is empty")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,15 +12,20 @@ import (
 	"github.com/lattots/bhproxy/pkg/utility"
 )
 
-func main() {
-	dotEnvPath := utility.GetDotEnvPath()
-	if utility.FileExists(dotEnvPath) {
-		err := godotenv.Load(utility.GetDotEnvPath())
+func routeLogMessages(logFileName string) *os.File {
+	if logFileName != "" {
+		logFile, err := os.OpenFile(logFileName, os.O_APPEND|os.O_RDWR|os.O_CREATE, 0644)
 		if err != nil {
-			log.Fatalf("could not read .env file at %s: %s", dotEnvPath, err)
+			log.Fatalf("could not open log file %s for append: %s", logFileName, err)
 		}
+
+		return logFile
 	}
 
+	return nil
+}
+
+func getDatabaseFilename() string {
 	databaseFilename := os.Getenv("BHP_DB_FILENAME")
 	if databaseFilename == "" {
 		log.Fatal("required environment variable db_filename is not set or is empty")
@@ -32,6 +37,26 @@ func main() {
 	if !utility.FileIsWriteable(databaseFilename) {
 		log.Fatalf("database file %s is not writeable", databaseFilename)
 	}
+
+	return databaseFilename
+}
+
+func main() {
+	dotEnvPath := utility.GetDotEnvPath()
+	if utility.FileExists(dotEnvPath) {
+		err := godotenv.Load(utility.GetDotEnvPath())
+		if err != nil {
+			log.Fatalf("could not read .env file at %s: %s", dotEnvPath, err)
+		}
+	}
+
+	logFile := routeLogMessages(os.Getenv("BHP_LOGFILE"))
+	if logFile != nil {
+		defer logFile.Close()
+		log.SetOutput(logFile)
+	}
+
+	databaseFilename := getDatabaseFilename()
 
 	h, err := handler.NewSqliteHandler(databaseFilename)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require modernc.org/sqlite v1.35.0
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd h1:gbpYu9NMq8jhDVbvlG
 github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd/go.mod h1:kf6iHlnVGwgKolg33glAes7Yg/8iWP8ukqeldJSO7jw=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=

--- a/index.html
+++ b/index.html
@@ -3,25 +3,28 @@
     <head>
         <script>
             window.onload = function() {
-                async function getResponse(url) {
-                    console.debug('getResponse', url)
+                async function getResponse(proxyUrl, beholdFeedID) {
+                    console.debug('getResponse', proxyUrl, beholdFeedID)
 
-                    const response = await fetch(`${url}?id=BEHOLD_FEED_ID`, {
+                    const response = await fetch(`${proxyUrl}?id=${beholdFeedID}`, {
                         method: 'GET'
                     })
 
                     if (response.ok) {
                         const data = await response.json()
                         document.getElementById('response').value = JSON.stringify(data)
+                        document.getElementById('latestError').textContent = ''
                     }
                     else {
                         console.debug('fetch failed', response)
+                        document.getElementById('latestError').textContent = `#${response.status}: ${response.statusText}`
                     }
                 }
 
                 document.getElementById('getResponseGo').addEventListener('click', async function(event) {
-                    event.preventDefault();
-                    await getResponse('cgi-bin/bhproxy')
+                    event.preventDefault()
+                    const beholdFeedID = document.getElementById('beholdFeedID').value
+                    await getResponse('/cgi-bin/bhproxy', beholdFeedID)
                 })
 
                 console.debug('onload executed')
@@ -29,7 +32,11 @@
         </script>
     </head>
     <body>
-        <button id="getResponseGo">Get response (Go)</button>
-        <textarea id="response" rows="20" cols="40"></textarea>
+        <p>
+            Behold Feed ID: <input type="text" id="beholdFeedID"><br/>
+            <button id="getResponseGo">Get bhproxy JSON</button>
+        </p>
+        <textarea id="response" rows="20" cols="40"></textarea><br/>
+        Latest error: <div id="latestError"></div>
     </body>    
 </html>

--- a/pkg/feed/feed.go
+++ b/pkg/feed/feed.go
@@ -168,7 +168,7 @@ func (f *Feed) insertToDB(db *sql.DB) error {
 }
 
 func getImageDirectory() (string, error) {
-	imageDirectory := os.Getenv("IMAGE_DIRECTORY")
+	imageDirectory := os.Getenv("BHP_IMAGE_DIRECTORY")
 	if imageDirectory == "" {
 		return "", errors.New("required environment variable image_directory is not set or is empty")
 	}
@@ -177,7 +177,7 @@ func getImageDirectory() (string, error) {
 }
 
 func getImageURL() string {
-	return os.Getenv("IMAGE_URL")
+	return os.Getenv("BHP_IMAGE_URL")
 }
 
 func ensurePostImagesExist(db *sql.DB, postIDs []string) ([]string, error) {

--- a/pkg/utility/utility.go
+++ b/pkg/utility/utility.go
@@ -1,6 +1,10 @@
 package utility
 
-import "os"
+import (
+	"log"
+	"os"
+	"path/filepath"
+)
 
 func FileExists(filepath string) bool {
 	_, err := os.Stat(filepath)
@@ -12,4 +16,14 @@ func FileIsWriteable(filepath string) bool {
 	_, err := os.OpenFile(filepath, os.O_RDWR, 0666)
 
 	return err == nil
+}
+
+func GetDotEnvPath() string {
+	executable, err := os.Executable()
+	if err != nil {
+		log.Printf("could not get path of the executable script: %s", err)
+		return ".env"
+	}
+
+	return filepath.Join(filepath.Dir(executable), ".env")
 }

--- a/pkg/utility/utility.go
+++ b/pkg/utility/utility.go
@@ -1,0 +1,15 @@
+package utility
+
+import "os"
+
+func FileExists(filepath string) bool {
+	_, err := os.Stat(filepath)
+
+	return err == nil
+}
+
+func FileIsWriteable(filepath string) bool {
+	_, err := os.OpenFile(filepath, os.O_RDWR, 0666)
+
+	return err == nil
+}

--- a/pkg/utility/utility_test.go
+++ b/pkg/utility/utility_test.go
@@ -1,0 +1,41 @@
+package utility
+
+import (
+	"os"
+	"testing"
+)
+
+func TestFileExists(t *testing.T) {
+	f, err := os.CreateTemp("", "bhproxy-test")
+	defer os.Remove(f.Name())
+	if err != nil {
+		t.Errorf("Could not create temporary file: %s", err)
+	}
+
+	if !FileExists(f.Name()) {
+		t.Errorf("FileExists returns true although file should exist")
+	}
+
+	os.Remove(f.Name())
+
+	if FileExists(f.Name()) {
+		t.Errorf("FileExists returns true although file does not exist")
+	}
+}
+
+func TestFileIsWriteable(t *testing.T) {
+	f, err := os.CreateTemp("", "bhproxy-test")
+	defer os.Remove(f.Name())
+	if err != nil {
+		t.Errorf("Could not create temporary file: %s", err)
+	}
+
+	err = os.Chmod(f.Name(), 0400)
+	if err != nil {
+		t.Errorf("Could not change file permissions: %s", err)
+	}
+
+	if FileIsWriteable(f.Name()) {
+		t.Errorf("FileIsWriteable returns true although file should not be writeable")
+	}
+}


### PR DESCRIPTION
These changes try to make it easier for admins to host the script:
 * All parameters can be set via environment variables. This makes it easy to run bhproxy in a container.
 * The parameters can also be set using `.env` file.
 * A local development web server demonstrates the latter way of setting things up.
